### PR TITLE
Update 'base model path' for SD2.1

### DIFF
--- a/configs/sd2_gradio.yaml
+++ b/configs/sd2_gradio.yaml
@@ -1,5 +1,5 @@
 base_model_type: sd2
-base_model_path: stabilityai/stable-diffusion-2-1-base
+base_model_path: sd2-community/stable-diffusion-2-1-base
 model_t: 200
 coeff_t: 200
 lora_rank: 256

--- a/configs/sd2_train.yaml
+++ b/configs/sd2_train.yaml
@@ -70,7 +70,7 @@ data_config:
         resize_back: true
 
 base_model_type: sd2
-base_model_path: stabilityai/stable-diffusion-2-1-base
+base_model_path: sd2-community/stable-diffusion-2-1-base
 model_t: 200
 coeff_t: 200
 lora_rank: 256


### PR DESCRIPTION
It seems StabilityAI has decided to take the `stabilityai/stable-diffusion-2-1-base` repo offline.
At the moment, there is a working mirror hosted by `sd2-community` though, which this PR switches to.